### PR TITLE
Temps can be null

### DIFF
--- a/src/TeslaAPI/Models/ClimateState.cs
+++ b/src/TeslaAPI/Models/ClimateState.cs
@@ -26,7 +26,7 @@
         public int FanStatus { get; set; }
 
         [JsonProperty("inside_temp")]
-        public double InsideTemperature { get; set; }
+        public double? InsideTemperature { get; set; }
 
         [JsonProperty("is_auto_conditioning_on")]
         public bool IsAutoConditioningOn { get; set; }
@@ -53,7 +53,7 @@
         public double MinimumAvailableTemperature { get; set; }
 
         [JsonProperty("outside_temp")]
-        public double OutsideTemperature { get; set; }
+        public double? OutsideTemperature { get; set; }
 
         [JsonProperty("passenger_temp_setting")]
         public double PassengerTempSetting { get; set; }


### PR DESCRIPTION
Temps can be null, resolves:

```txt
 "Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.Double'. Path 'response.inside_temp', line 1, position 294."
```