### PR TITLE
Capture the response in the returned exception in case of deserialization errors

### DIFF
--- a/src/TeslaAPI/TeslaAPI.cs
+++ b/src/TeslaAPI/TeslaAPI.cs
@@ -1213,7 +1213,17 @@
                 throw new Exception(errorMessage);
             }
 
-            return JsonConvert.DeserializeObject<T>(await response.Content.ReadAsStringAsync());
+            string json = await response.Content.ReadAsStringAsync();
+
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(json);
+            }
+            catch (Exception e)
+            {
+                e.Data["TeslaAPI.Response"] = json;
+                throw;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Capture the response in the returned exception in case of deserialization errors. Will log the exception data property in logging frameworks that are configured to do so.

Should help avoiding one by one deserialization issues as response can be diagnosed for potential additional deserialization issues or even be added to a unit test.