### PR TITLE
Update SpeedLimitMode.cs

### DIFF
--- a/src/Tesla.API/Models/SpeedLimitMode.cs
+++ b/src/Tesla.API/Models/SpeedLimitMode.cs
@@ -14,10 +14,10 @@
         public double CurrentLimitMilesPerHour { get; set; }
 
         [JsonProperty("max_limit_mph")]
-        public int MaximumLimitMilesPerHour { get; set; }
+        public double MaximumLimitMilesPerHour { get; set; }
 
         [JsonProperty("min_limit_mph")]
-        public int MinimumLimitMilesPerHour { get; set; }
+        public double MinimumLimitMilesPerHour { get; set; }
 
         [JsonProperty("pin_code_set")]
         public bool PINCodeSet { get; set; }


### PR DESCRIPTION
Trying to query the vehicle state throws a JsonException:
Input string '50.0' is not a valid integer. Path 'response.speed_limit_mode.min_limit_mph', line 1, position 915.
SpeedLimitMode.MinimumLimitMilesPerHour and SpeedLimitMode.MaximumLimitMilesPerHour seem to be doubles, not ints.
Just like CurrentLimitMilesPerHour.

hth
mav