### PR TITLE
Fixed issue with ClimateState BatteryHeaterNoPower

### DIFF
--- a/src/TeslaAPI/Models/ClimateState.cs
+++ b/src/TeslaAPI/Models/ClimateState.cs
@@ -11,7 +11,7 @@
         public bool BatteryHeater { get; set; }
 
         [JsonProperty("battery_heater_no_power")]
-        public bool BatteryHeaterNoPower { get; set; }
+        public bool? BatteryHeaterNoPower { get; set; }
 
         [JsonProperty("climate_keeper_mode")]
         public string ClimateKeeperMode { get; set; }

--- a/src/TeslaAPI/Models/VehicleConfig.cs
+++ b/src/TeslaAPI/Models/VehicleConfig.cs
@@ -80,13 +80,13 @@
         public string RoofColor { get; set; }
 
         [JsonProperty("seat_type")]
-        public int SeatType { get; set; }
+        public int? SeatType { get; set; }
 
         [JsonProperty("spoiler_type")]
         public string SpoilerType { get; set; }
 
         [JsonProperty("sun_roof_installed")]
-        public int SunroofInstalled { get; set; }
+        public int? SunroofInstalled { get; set; }
 
         [JsonProperty("third_row_seats")]
         public string ThirdRowSeats { get; set; }


### PR DESCRIPTION
Tesla's API can return null for the battery_heater_no_power for the ClimateState