### PR TITLE
Fix for "Endpoint is only available on fleetapi."

### DIFF
--- a/src/TeslaAPI.cs
+++ b/src/TeslaAPI.cs
@@ -1,4 +1,4 @@
-﻿namespace TeslaAPI
+namespace TeslaAPI
 {
     using System;
     using System.Collections.Generic;
@@ -119,7 +119,7 @@
         /// <inheritdoc/>
         public Task<List<Vehicle>> GetAllVehiclesAsync(HttpClient client)
         {
-            HttpRequestMessage request = BuildRequest(HttpMethod.Get, $"{OwnerApiBaseUrl}{ApiV1}/vehicles");
+            HttpRequestMessage request = BuildRequest(HttpMethod.Get, $"{OwnerApiBaseUrl}{ApiV1}/products");
             return SendRequestResponseListUnwrapAsync<Vehicle>(client, request);
         }
 


### PR DESCRIPTION
Fix for TeslaAPI.Exceptions.TeslaApiRequestUnsuccessfulException : Endpoint is only available on fleetapi. Visit https://developer.tesla.com/docs for more info.

Based on various reported "current" workarounds.